### PR TITLE
Speed improvement in make_cicero_cds function.

### DIFF
--- a/R/runCicero.R
+++ b/R/runCicero.R
@@ -133,12 +133,12 @@ make_cicero_cds <- function(cds,
   
   exprs_old <- exprs(cds)
   
-  x <- lapply(seq_len(nrow(cell_sample)), function(x) {
-    return(Matrix::rowSums(exprs_old %*%
-                             Matrix::Diagonal(x=seq_len(ncol(exprs_old)) %in%
-                                                cell_sample[x,,drop=FALSE])))})
-
-  new_exprs <- do.call(rbind, x)
+  mask <- sapply(seq_len(nrow(cell_sample)), function(x) seq_len(ncol(exprs_old)) %in% cell_sample[x,,drop=FALSE])
+  mask <- Matrix(mask)
+  new_exprs <- exprs_old %*% mask
+  
+  new_exprs <- t(new_exprs)
+  new_exprs <- as.matrix(new_exprs)
   
   pdata <- pData(cds)
   new_pcols <- "agg_cell"


### PR DESCRIPTION
Profiling showed that in large >1k 10x datasets this function took over an hour to complete due to an expensive operation in the lapply loop. I modified the function to avoid this expensive code path while still obtaining the same matrix.